### PR TITLE
[softwaremanage] Create states maps in update method

### DIFF
--- a/unitstatushandler/softwaremanager.go
+++ b/unitstatushandler/softwaremanager.go
@@ -633,6 +633,14 @@ func (manager *softwareManager) readyToUpdate() {
 func (manager *softwareManager) update(ctx context.Context) {
 	var updateErr string
 
+	if manager.LayerStatuses == nil {
+		manager.LayerStatuses = make(map[string]*cloudprotocol.LayerStatus)
+	}
+
+	if manager.ServiceStatuses == nil {
+		manager.ServiceStatuses = make(map[string]*cloudprotocol.ServiceStatus)
+	}
+
 	defer func() {
 		go func() {
 			manager.Lock()

--- a/unitstatushandler/softwaremanager.go
+++ b/unitstatushandler/softwaremanager.go
@@ -60,7 +60,7 @@ type softwareUpdate struct {
 	RestoreServices []cloudprotocol.ServiceInfo      `json:"restoreServices,omitempty"`
 	InstallLayers   []cloudprotocol.LayerInfo        `json:"installLayers,omitempty"`
 	RemoveLayers    []cloudprotocol.LayerStatus      `json:"removeLayers,omitempty"`
-	RestoreLayers   []cloudprotocol.LayerStatus      `json:"remstoreLayers,omitempty"`
+	RestoreLayers   []cloudprotocol.LayerStatus      `json:"restoreLayers,omitempty"`
 	RunInstances    []cloudprotocol.InstanceInfo     `json:"runInstances,omitempty"`
 	CertChains      []cloudprotocol.CertificateChain `json:"certChains,omitempty"`
 	Certs           []cloudprotocol.Certificate      `json:"certs,omitempty"`


### PR DESCRIPTION
In case of starting power in updating state, stateas maps do not exist. To avoid panic create maps in the update method

Signed-off-by: Yevgen Abramov <Yevgen_Abramov@epam.com>